### PR TITLE
created logic migrations deployment script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,13 +68,13 @@ jobs:
     - npm install
     script:
     - ../travis/runTests.sh
-  - stage: solidity-tests-sidechain
-    install:
-    - npm install -g ganache-cli@6.2.3 truffle@5.0.1
-    - cd sidechain
-    - npm install
-    script:
-    - ../travis/runTests.sh
+  # - stage: solidity-tests-sidechain
+  #   install:
+  #   - npm install -g ganache-cli@6.2.3 truffle@5.0.1
+  #   - cd sidechain
+  #   - npm install
+  #   script:
+  #   - ../travis/runTests.sh
   - stage: git-tag
     if: "(NOT type IN (pull_request) AND (branch = master))"
     install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,13 +68,13 @@ jobs:
     - npm install
     script:
     - ../travis/runTests.sh
-  # - stage: solidity-tests-sidechain
-  #   install:
-  #   - npm install -g ganache-cli@6.2.3 truffle@5.0.1
-  #   - cd sidechain
-  #   - npm install
-  #   script:
-  #   - ../travis/runTests.sh
+  - stage: solidity-tests-sidechain
+    install:
+    - npm install -g ganache-cli@6.2.3 truffle@5.0.1
+    - cd sidechain
+    - npm install
+    script:
+    - ../travis/runTests.sh
   - stage: git-tag
     if: "(NOT type IN (pull_request) AND (branch = master))"
     install:

--- a/sidechain/contracts/group/Group.sol
+++ b/sidechain/contracts/group/Group.sol
@@ -299,7 +299,7 @@ contract Group is GroupI, UsingExternalStorage
     //  invitation logic
     //
 
-    function inviteUserToGroupSignature(
+    function prepareInviteUserToGroup(
         uint256 _groupId, 
         uint8   _role,
         bytes32 _secretHash,

--- a/sidechain/migrations/2_deploy_dependency_contracts.js
+++ b/sidechain/migrations/2_deploy_dependency_contracts.js
@@ -4,28 +4,13 @@ let OnlyOwnerAdminController = artifacts.require('OnlyOwnerAdminController');
 
 async function performMigration(deployer, network, accounts) {
     await deployer.deploy(Storage);
-    await deployer.deploy(Group, [2, 3]);
     await deployer.deploy(OnlyOwnerAdminController);
 
     let deployedStorage = await Storage.deployed();
 
-    console.log("Setting admin controller to OnlyOwnerAdminController for Storage contract...")
+    console.log("Setting admin controller to OnlyOwnerAdminController for Storage contract...");
     await deployedStorage.setAdminController(OnlyOwnerAdminController.address);
-
-    console.log("Adding Storage write permission for Community...");
-    await deployedStorage.addWritePermission(Group.address);
-
-    let deployedGroup = await Group.deployed();
-
-    console.log("Setting admin controller to OnlyOwnerAdminController for Community conract...");
-    await deployedGroup.setAdminController(OnlyOwnerAdminController.address)
-
-    console.log("Setting storage address on Group...");
-    await deployedGroup.setStorageContractAddress(Storage.address);
-
-    console.log("Group address: " + Group.address);
-
-}
+};
 
 module.exports = function(deployer, network, accounts) {
     deployer
@@ -36,4 +21,4 @@ module.exports = function(deployer, network, accounts) {
             console.log(error)
             process.exit(1)
         })
-}
+};

--- a/sidechain/migrations/3_deploy_logic_contracts.js
+++ b/sidechain/migrations/3_deploy_logic_contracts.js
@@ -3,7 +3,7 @@ let Storage                     = artifacts.require('Storage');
 let OnlyOwnerAdminController    = artifacts.require('OnlyOwnerAdminController');
 
 async function performMigration(deployer, network, accounts) {
-    await deployer.deploy(Group, []);
+    await deployer.deploy(Group, [2]);
     
     let deployedStorage = await Storage.deployed();
 

--- a/sidechain/migrations/3_deploy_logic_contracts.js
+++ b/sidechain/migrations/3_deploy_logic_contracts.js
@@ -1,0 +1,33 @@
+let Group                       = artifacts.require('Group');
+let Storage                     = artifacts.require('Storage');
+let OnlyOwnerAdminController    = artifacts.require('OnlyOwnerAdminController');
+
+async function performMigration(deployer, network, accounts) {
+    await deployer.deploy(Group, []);
+    
+    let deployedStorage = await Storage.deployed();
+
+    console.log("Adding Storage write permission for Group...");
+    await deployedStorage.addWritePermission(Group.address);
+
+    let deployedGroup = await Group.deployed();
+
+    console.log("Setting admin controller to OnlyOwnerAdminController for Group contract...");
+    await deployedGroup.setAdminController(OnlyOwnerAdminController.address);
+
+    console.log("Setting storage address on Group...");
+    await deployedGroup.setStorageContractAddress(Storage.address);
+    
+    console.log("Group address: " + Group.address);
+}
+
+module.exports = function(deployer, network, accounts) {
+    deployer
+        .then(function() {
+            return performMigration(deployer, network, accounts)
+        })
+        .catch(error => {
+            console.log(error)
+            process.exit(1)
+        })
+}

--- a/sidechain/test/test_group.js
+++ b/sidechain/test/test_group.js
@@ -2,46 +2,40 @@
 (async () => {
 
     const Group = artifacts.require("Group.sol");
-    const Storage = artifacts.require("Storage.sol");
-    const AdminController = artifacts.require("OnlyOwnerAdminController.sol");
+    const Storage               = artifacts.require("Storage.sol");
+    const AdminController       = artifacts.require("OnlyOwnerAdminController.sol");
 
-    const catchRevert = require('./exceptions.js').catchRevert;
-    const EthUtil =     require('ethereumjs-util');
-    const ipfsHash =    require('./helpers/ipfsHash');
-    const getEvents =   require('./helpers/getEvents').getEvents;
+    const catchRevert           = require('./exceptions.js').catchRevert;
+    const EthUtil               = require('ethereumjs-util');
+    const ipfsHash              = require('./helpers/ipfsHash');
+    const getEvents             = require('./helpers/getEvents').getEvents;
 
-    const IPFS_HASH = "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco";
-    const METADATA_HASH = ipfsHash.getBytes32FromIpfsHash(IPFS_HASH);
+    const IPFS_HASH             = "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco";
+    const METADATA_HASH         = ipfsHash.getBytes32FromIpfsHash(IPFS_HASH);
 
     let groupInstance;
     let storageInstance;
     let adminController;
 
-    let testprivkey = '552ee2ef4bff3c2edbb1a169b0b0925d68dfd1b6f1d0025d2165bf5f1785e5c3'; 
-
     contract('Group', async accounts => {
 
         beforeEach(async () => {
-            storageInstance = await Storage.new();
-            groupInstance = await Group.new([2,3]);
-            adminController = await AdminController.new();
+            storageInstance     = await Storage.new();
+            groupInstance       = await Group.new([2]);
+            adminController     = await AdminController.new();
 
             await storageInstance.setAdminController(adminController.address);
             await groupInstance.setAdminController(adminController.address);
-            
             await groupInstance.setStorageContractAddress(storageInstance.address);
             await storageInstance.addWritePermission(groupInstance.address);
 
         });
 
         it('should create a group', async () => {
-            let metadataLocator = web3.utils.toHex('1337'); 
             let nonce           = await groupInstance.nonces.call(accounts[0]);
-            
-            let hash            = await groupInstance.prepareCreateGroup(metadataLocator, nonce);
+            let hash            = await groupInstance.prepareCreateGroup(METADATA_HASH, nonce);
             let sig             = await web3.eth.sign(hash, web3.utils.toChecksumAddress(accounts[0]));
-            
-            let newGroup        = await groupInstance.createGroup(metadataLocator, sig, nonce);
+            let newGroup        = await groupInstance.createGroup(METADATA_HASH, sig, nonce);
             let newSequence     = await groupInstance.sequence.call();
 
             assert.equal(
@@ -52,23 +46,22 @@
         });
 
         it('should retrieve the correct nonce', async () => {
-            let retrieveNonce = await groupInstance.nonces.call(accounts[0]);
+            let retrieveNonce   = await groupInstance.nonces.call(accounts[0]);
 
             assert.equal(
                 retrieveNonce, 
                 0
             );
 
-            let metadataLocator = web3.utils.toHex('1337'); 
             let nonce = await groupInstance.nonces.call(accounts[0]);
             let hash            = await groupInstance.prepareCreateGroup(
-                metadataLocator, 
+                METADATA_HASH, 
                 nonce 
             );
 
             let sig             = await web3.eth.sign(hash, web3.utils.toChecksumAddress(accounts[0]));
             let newGroup        = await groupInstance.createGroup(
-                metadataLocator, 
+                METADATA_HASH, 
                 sig, 
                 nonce,
                 { from: accounts[0] }
@@ -84,23 +77,18 @@
         });
 
         it('should fail to create a group because of incorrect nonce', async () => {
-            let metadataLocator = web3.utils.toHex('1337'); 
             let incorrectNonce  = 1;
-            let hash            = await groupInstance.prepareCreateGroup(metadataLocator, incorrectNonce);
+            let hash            = await groupInstance.prepareCreateGroup(METADATA_HASH, incorrectNonce);
             let sig             = await web3.eth.sign(hash, web3.utils.toChecksumAddress(accounts[0]));
 
-            await catchRevert(groupInstance.createGroup(metadataLocator, sig, incorrectNonce));
-        })
+            await catchRevert(groupInstance.createGroup(METADATA_HASH, sig, incorrectNonce));
+        });
 
         it('should emit a GroupCreated event after group creation', async () => {
-
-            let metadataLocator = web3.utils.toHex('1337');
             let nonce           = await groupInstance.nonces.call(accounts[0]);
-
-            let hash            = await groupInstance.prepareCreateGroup(metadataLocator, nonce);
+            let hash            = await groupInstance.prepareCreateGroup(METADATA_HASH, nonce);
             let sig             = await web3.eth.sign(hash, web3.utils.toChecksumAddress(accounts[0]));
-
-            let groupCreated = await groupInstance.createGroup(metadataLocator, sig, nonce);
+            let groupCreated = await groupInstance.createGroup(METADATA_HASH, sig, nonce);
 
             const logGroupCreated = groupCreated.logs[0];
 
@@ -125,14 +113,10 @@
         });
 
         it('should emit a MemberAdded event after group creation', async () => {
-
-            let metadataLocator = web3.utils.toHex('1337');
             let nonce           = 0;
-
-            let hash            = await groupInstance.prepareCreateGroup(metadataLocator, nonce);
+            let hash            = await groupInstance.prepareCreateGroup(METADATA_HASH, nonce);
             let sig             = await web3.eth.sign(hash, web3.utils.toChecksumAddress(accounts[0]));
-
-            let groupCreated = await groupInstance.createGroup(metadataLocator, sig, nonce);
+            let groupCreated    = await groupInstance.createGroup(METADATA_HASH, sig, nonce);
 
             const logGroupCreated = groupCreated.logs[1];
 
@@ -162,14 +146,12 @@
         //
 
         it('should return message hash for member invitation', async () => {
-            let groupId     = 0;
-            let role        = 2;
-            let secret      = web3.utils.toHex('1337');
-            let secretHash  = web3.utils.sha3(secret);
-
-            let nonce       = await groupInstance.nonces.call(accounts[0]);
-
-            let inviteCreated = await groupInstance.inviteUserToGroupSignature(
+            let groupId         = 0;
+            let role            = 2;
+            let secret          = web3.utils.toHex('1337');
+            let secretHash      = web3.utils.sha3(secret);
+            let nonce           = await groupInstance.nonces.call(accounts[0]);
+            let inviteCreated   = await groupInstance.inviteUserToGroupSignature(
                 groupId,
                 role,
                 secretHash,
@@ -180,7 +162,17 @@
         });
 
         it('should emit InvitationPending event after sending tx', async () => {
-            
+            let test1 = 0;
+            let test2 = 1;
+
+            assert.equal(test1, test2);
+        });
+
+        it('should add new member upon receipt of acceptInvitationCommit', async () => {
+            let test1 = 0;
+            let test2 = 1;
+
+            assert.equal(test1, test2);
         })
 
     });

--- a/sidechain/test/test_group.js
+++ b/sidechain/test/test_group.js
@@ -88,7 +88,7 @@
             let nonce           = await groupInstance.nonces.call(accounts[0]);
             let hash            = await groupInstance.prepareCreateGroup(METADATA_HASH, nonce);
             let sig             = await web3.eth.sign(hash, web3.utils.toChecksumAddress(accounts[0]));
-            let groupCreated = await groupInstance.createGroup(METADATA_HASH, sig, nonce);
+            let groupCreated    = await groupInstance.createGroup(METADATA_HASH, sig, nonce);
 
             const logGroupCreated = groupCreated.logs[0];
 


### PR DESCRIPTION
went ahead and split the Group deployment out of dependencies script and placed it in own script, as well as some cosmetic changes, eliminating some unused lines, and replacing the temporary metadataLocator data with the actual IPFS and metadataHash variables.